### PR TITLE
Fix typo 'abandonned'

### DIFF
--- a/Sources/Elastos/Frameworks/Droid/Base/Core/car/elastos/droid/media/AudioManager.car
+++ b/Sources/Elastos/Frameworks/Droid/Base/Core/car/elastos/droid/media/AudioManager.car
@@ -1995,7 +1995,7 @@ module
          *  @param l the listener to be notified of audio focus changes
          *  @param streamType the main audio stream type affected by the focus request
          *  @param durationHint use {@link #AUDIOFOCUS_GAIN_TRANSIENT} to indicate this focus request
-         *      is temporary, and focus will be abandonned shortly. Examples of transient requests are
+         *      is temporary, and focus will be abandoned shortly. Examples of transient requests are
          *      for the playback of driving directions, or notifications sounds.
          *      Use {@link #AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK} to indicate also that it's ok for
          *      the previous focus owner to keep playing if it ducks its audio output.

--- a/Sources/Elastos/Frameworks/Droid/Base/Core/inc/elastos/droid/media/CAudioManager.h
+++ b/Sources/Elastos/Frameworks/Droid/Base/Core/inc/elastos/droid/media/CAudioManager.h
@@ -805,7 +805,7 @@ public:
      *  @param l the listener to be notified of audio focus changes
      *  @param streamType the main audio stream type affected by the focus request
      *  @param durationHint use {@link #AUDIOFOCUS_GAIN_TRANSIENT} to indicate this focus request
-     *      is temporary, and focus will be abandonned shortly. Examples of transient requests are
+     *      is temporary, and focus will be abandoned shortly. Examples of transient requests are
      *      for the playback of driving directions, or notifications sounds.
      *      Use {@link #AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK} to indicate also that it's ok for
      *      the previous focus owner to keep playing if it ducks its audio output.


### PR DESCRIPTION

    Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
    should be 'abandoned', you typed 'abandonned'. I created this pull request to fix it!

    If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
    at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
    I’m aware of it.

    Looking for the source code of this bot? Well, you have to be patient! The bot is under development
    and I will publish the source code as soon as I’m finished with it.

    With kind regards,
    TheTypoMaster
                